### PR TITLE
Fix error propagation and package.json syntax

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { PDFDocument, rgb } = require('pdf-lib');
+const { PDFDocument } = require('pdf-lib');
 
 async function fillCertificate(templatePath, outputPath, fieldValues) {
   try {
@@ -24,6 +24,7 @@ async function fillCertificate(templatePath, outputPath, fieldValues) {
     await fs.promises.writeFile(outputPath, modifiedPdfBytes);
   } catch (error) {
     console.error('An error occurred:', error);
+    throw error;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "pdf-lib": "^1.10.0"
-  }
+  },
   "keywords": [
     "pdf",
     "certificate",


### PR DESCRIPTION
## Summary
- propagate errors in `fillCertificate`
- clean up import from pdf-lib
- fix package.json syntax

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fe6dab484832c8e92bc1cc15d7d8a